### PR TITLE
Do no declare default features for mfem-sys

### DIFF
--- a/crates/mfem-sys/Cargo.toml
+++ b/crates/mfem-sys/Cargo.toml
@@ -18,7 +18,6 @@ mfem-cpp = { version = "0.2", path = "../mfem-cpp", optional = true }
 semver = "1.0.22"
 
 [features]
-default = ["bundled"]
 bundled = ["mfem-cpp"]
 
 [dev-dependencies]


### PR DESCRIPTION
The problem is that specifying `default-features = false` for `mfem` does not propagate to `mfem-sys`, so `mfem-cpp` is de facto always required (even if one wants to use the system libraries).

Fixes https://github.com/mkovaxx/mfem-rs/issues/3