### PR TITLE
Windows: use `cfg` for windows specific options

### DIFF
--- a/crates/mfem-sys/Cargo.toml
+++ b/crates/mfem-sys/Cargo.toml
@@ -18,7 +18,6 @@ mfem-cpp = { version = "0.2", path = "../mfem-cpp", optional = true }
 semver = "1.0.22"
 
 [features]
-default = ["bundled"]
 bundled = ["mfem-cpp"]
 
 [dev-dependencies]


### PR DESCRIPTION
Windows: use `cfg` for windows specific options.

Fixes https://github.com/mkovaxx/mfem-rs/issues/5