### PR TITLE
Fix the build of `mfem-sys` with a system `mfem`.

### DIFF
--- a/crates/mfem-sys/Cargo.toml
+++ b/crates/mfem-sys/Cargo.toml
@@ -18,7 +18,6 @@ mfem-cpp = { version = "0.2", path = "../mfem-cpp", optional = true }
 semver = "1.0.22"
 
 [features]
-default = ["bundled"]
 bundled = ["mfem-cpp"]
 
 [dev-dependencies]

--- a/crates/mfem-sys/MFEM/CMakeLists.txt
+++ b/crates/mfem-sys/MFEM/CMakeLists.txt
@@ -1,13 +1,23 @@
-cmake_minimum_required (VERSION 3.1 FATAL_ERROR)
+cmake_minimum_required (VERSION 3.5 FATAL_ERROR)
 project (MfemPackageConfig)
 
 set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE "BOTH" CACHE PATH "")
 
-find_package (MFEM REQUIRED)
+message(STATUS "Looking for mfem ...")
+set(MFEM_DIR "" CACHE PATH "Path to the MFEM build or install prefix.")
+if (MFEM_DIR)
+   find_package(mfem REQUIRED NAMES MFEM HINTS "${MFEM_DIR}"
+                "${MFEM_DIR}/lib/cmake/mfem" NO_DEFAULT_PATH)
+else()
+   find_package(mfem REQUIRED NAMES MFEM)
+endif()
 
 file (WRITE ${CMAKE_BINARY_DIR}/mfem_info.txt
       "VERSION=${MFEM_VERSION}\n"
-      "INCLUDE_DIR=${MFEM_INCLUDE_DIR}\n"
-      "LIBRARY_DIR=${MFEM_LIBRARY_DIR}\n")
+      "MFEM_LIBRARIES=${MFEM_LIBRARIES}\n"
+      "INCLUDE_DIRS=${MFEM_INCLUDE_DIRS}\n"
+      "LIBRARY_DIR=${MFEM_LIBRARY_DIR}\n"
+      "CXX_FLAGS=${MFEM_CXX_FLAGS}\n"
+)
 
 install (FILES ${CMAKE_BINARY_DIR}/mfem_info.txt TYPE DATA)

--- a/crates/mfem-sys/README.md
+++ b/crates/mfem-sys/README.md
@@ -15,4 +15,7 @@ Please file an issue and bear with us while we sort things out! Thanks! :)
 - Uses the `cxx` crate to generate safe and correct bindings.
 - Encodes MFEM's ownership rules into Rust's type system.
 - Turns various MFEM `int` constants into type-safe Rust `enum`s.
-- Depends on `mfem-cpp`.
+- Optionally depends on `mfem-cpp`: if the C++ libraries `libmfem` is
+  not installed on you system (with the development files, e.g. via
+  the package `libmfem-dev` on Debian), activate the feature `bundled`
+  so that `libmfem` is compiled in your project.

--- a/crates/mfem-sys/build.rs
+++ b/crates/mfem-sys/build.rs
@@ -1,6 +1,4 @@
 /// The list of used MFEM libraries which needs to be linked with.
-const MFEM_LIBS: &[&str] = &["mfem"];
-
 fn main() {
     let target = std::env::var("TARGET").expect("No TARGET environment variable defined");
     let is_windows = target.to_lowercase().contains("windows");
@@ -12,9 +10,11 @@ fn main() {
         mfem_config.library_dir.to_str().unwrap()
     );
 
-    let lib_type = "static";
-    for lib in MFEM_LIBS {
-        println!("cargo:rustc-link-lib={lib_type}={lib}");
+    for lib in mfem_config.mfem_libs {
+        #[cfg(feature = "bundled")]
+        println!("cargo:rustc-link-lib=static={lib}");
+        #[cfg(not(feature = "bundled"))]
+        println!("cargo:rustc-link-lib={lib}");
     }
 
     if is_windows {
@@ -32,9 +32,13 @@ fn main() {
         .cpp(true)
         .std("c++14")
         .flag_if_supported("-w")
-        .include(mfem_config.include_dir)
-        .include("include")
-        .compile("wrapper");
+        .includes(mfem_config.include_dirs)
+        .include("include");
+    for f in mfem_config.cxx_flags {
+        build.flag_if_supported(f);
+    }
+
+    build.compile("wrapper");
 
     println!("cargo:rustc-link-lib=static=wrapper");
 
@@ -42,9 +46,12 @@ fn main() {
     println!("cargo:rerun-if-changed=include/wrapper.hpp");
 }
 
+#[derive(Debug)]
 struct MfemConfig {
-    include_dir: std::path::PathBuf,
+    mfem_libs: Vec<String>,
+    include_dirs: Vec<std::path::PathBuf>,
     library_dir: std::path::PathBuf,
+    cxx_flags: Vec<String>,
 }
 
 impl MfemConfig {
@@ -76,22 +83,38 @@ impl MfemConfig {
             .expect("Something went wrong when detecting MFEM.");
 
         let mut version: Option<semver::Version> = None;
-        let mut include_dir: Option<std::path::PathBuf> = None;
+        let mut mfem_libs: Vec<String> = vec![];
+        let mut include_dirs: Vec<std::path::PathBuf> = vec![];
         let mut library_dir: Option<std::path::PathBuf> = None;
+        let mut cxx_flags: Vec<String> = vec![];
 
         for line in cfg.lines() {
             if let Some((var, val)) = line.split_once('=') {
                 match var {
+                    // Keep in sync with "MFEM/CMakeLists.txt".
                     "VERSION" => version = semver::Version::parse(val).ok(),
-                    "INCLUDE_DIR" => include_dir = val.parse().ok(),
+                    "MFEM_LIBRARIES" => {
+                        for l in val.split(" ") { // FIXME: Right delim?
+                            mfem_libs.push(l.into());
+                        }
+                    }
+                    "INCLUDE_DIRS" => {
+                        for d in val.split(";") {
+                            include_dirs.push(d.into());
+                        }
+                    }
                     "LIBRARY_DIR" => library_dir = val.parse().ok(),
+                    "CXX_FLAGS" => {
+                        for f in val.split(" ") {
+                            cxx_flags.push(f.into());
+                        }
+                    }
                     _ => (),
                 }
             }
         }
 
-        if let (Some(version), Some(include_dir), Some(library_dir)) =
-            (version, include_dir, library_dir)
+        if let (Some(version), Some(library_dir)) = (version, library_dir)
         {
             if !version_req.matches(&version) {
                 #[cfg(feature = "bundled")]
@@ -100,12 +123,14 @@ impl MfemConfig {
 
                 #[cfg(not(feature = "bundled"))]
                 panic!("Pre-installed MFEM found but version is not met (found {} but {} required). Please provide required version or use `bundled` feature.",
-                       version, MFEM_VERSION);
+                       version, version_req);
             }
 
             Self {
-                include_dir,
+                mfem_libs,
+                include_dirs,
                 library_dir,
+                cxx_flags,
             }
         } else {
             panic!("MFEM found but something went wrong during configuration.");


### PR DESCRIPTION
Fix the build of `mfem-sys` with a system `mfem`.

Retrieve as much information as possible from cmake:
- the name of the library,
- the many include paths,
- the C++ flags.

Do not mandate a static lib — system libraries are in general dynamic.

Based on https://github.com/mkovaxx/mfem-rs/pull/6